### PR TITLE
conditionally load tooltips

### DIFF
--- a/includes/ayecode-ui-settings.php
+++ b/includes/ayecode-ui-settings.php
@@ -387,11 +387,18 @@ if ( ! class_exists( 'AyeCode_UI_Settings' ) ) {
 				 * Initiate tooltips on the page.
 				 */
 				function aui_init_tooltips(){
-					jQuery('[data-toggle="tooltip"]').tooltip();
-					jQuery('[data-toggle="popover"]').popover();
-					jQuery('[data-toggle="popover-html"]').popover({
-						html: true
-					});
+
+					if( jQuery.fn.tooltip ) {
+						jQuery('[data-toggle="tooltip"]').tooltip();
+					}
+					
+					if( jQuery.fn.popover ) {
+						jQuery('[data-toggle="popover"]').popover();
+						jQuery('[data-toggle="popover-html"]').popover({
+							html: true
+						});
+					}
+					
 				}
 
 				// run on window loaded


### PR DESCRIPTION
When bootstrap is not loaded (maybe by turning it off in wp-admin/options-general.php?page=ayecode-ui-settings), an error is thrown in the console preventing other inline scripts on the page from working
![init tooltips](https://user-images.githubusercontent.com/19934448/84764595-a38cd780-afd6-11ea-9f21-db966aad5ab2.jpg)
