### PR TITLE
Prevent running a query on every page load when not required - CHANGED

### DIFF
--- a/change-log.txt
+++ b/change-log.txt
@@ -1,3 +1,6 @@
+= 0.2.37 - 2025-06-TBD =
+* Prevent running a query on every page load when not required - CHANGED
+
 = 0.2.36 - 2025-05-01 =
 * WP 6.8 changed editor params and scroll page detector not working for fixed menu items color change - FIXED
 

--- a/includes/ayecode-ui-settings.php
+++ b/includes/ayecode-ui-settings.php
@@ -855,14 +855,16 @@ if ( ! class_exists( 'AyeCode_UI_Settings' ) ) {
 		 * @return array The array of settings.
 		 */
 		public function get_settings() {
-
 			$db_settings = get_option( 'ayecode-ui-settings' );
 
-            // Maybe show default version notice
-			$site_install_date = new DateTime( self::get_site_install_date() );
-			$switch_over_date = new DateTime("2024-02-01");
-			if ( empty( $db_settings ) && $site_install_date < $switch_over_date ) {
-				add_action( 'admin_notices', array( $this, 'show_admin_version_notice' ) );
+			// Maybe show default version notice
+			if ( empty( $db_settings ) ) {
+				$site_install_date = new DateTime( self::get_site_install_date() );
+				$switch_over_date = new DateTime( "2024-02-01" );
+
+				if ( $site_install_date < $switch_over_date ) {
+					add_action( 'admin_notices', array( $this, 'show_admin_version_notice' ) );
+				}
 			}
 
 			$js_default = 'core-popper';


### PR DESCRIPTION
Fixes #106

Query will not executed after AUI settings saved.