### PR TITLE
fix: remove Astra image box-shadow from Google Maps and Leaflet tiles

### DIFF
--- a/includes/ayecode-ui-settings.php
+++ b/includes/ayecode-ui-settings.php
@@ -1320,9 +1320,13 @@ $custom_css .= "
 				echo '.aui-nav-links .pagination{justify-content:inherit}';
 			}
 
-            // Astra theme - when woocommerce active they add compatibility CSS which breaks select2 in modals
+            // Astra theme compatibility fixes
             if( defined('ASTRA_THEME_VERSION')){
+				// WooCommerce active: breaks select2 z-index in modals
                 echo '.woocommerce-js.modal-open .select2-container .select2-dropdown, .woocommerce-js.modal-open .select2-container .select2-search__field, .woocommerce-page.modal-open .select2-container .select2-dropdown, .woocommerce-page.modal-open .select2-container .select2-search__field{z-index: 1056;}';
+
+				// Global image box-shadow breaks Google Maps / Leaflet tile rendering
+				echo '.leaflet-tile-container img,.gm-style img{box-shadow:none!important;}';
             }
 
 			?></style><?php


### PR DESCRIPTION
Astra's global image `box-shadow` breaks Google Maps / Leaflet tile rendering on GeoDirectory detail pages.

Reported: https://wordpress.org/support/topic/google-maps-tiles-appear-as-large-patchwork-folded-sections-on-details-page/

Fix: add `box-shadow: none` override to the existing Astra compatibility block in `custom_css()`.